### PR TITLE
Log test duration on success or failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@ erl_crash.dump
 
 .elixir_ls
 .vscode
-.tool-versions
 apps/playground/
 .DS_Store

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.13.0-otp-24
+erlang 24.3.4.13

--- a/apps/ex_cucumber/lib/ex_cucumber.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber.ex
@@ -154,7 +154,7 @@ defmodule ExCucumber do
               IO.ANSI.green() <>
                 describe_context(ctx) <>
                 " passed in #{duration_in_ms}ms" <>
-                IO.ANSI.reset() <> "\n"
+                IO.ANSI.reset() <> "\n\n"
             )
 
             {result, def_meta}
@@ -234,7 +234,7 @@ defmodule ExCucumber do
           IO.ANSI.red() <>
             describe_context(ctx) <>
             " failed after #{duration_in_ms}ms" <>
-            IO.ANSI.reset() <> "\n"
+            IO.ANSI.reset() <> "\n\n"
         )
 
         case Module.get_attribute(__MODULE__, :on_error) do
@@ -281,10 +281,11 @@ defmodule ExCucumber do
 
         [
           {"Feature", get_in(extra, [:feature, :title])},
-          {"Scenario", get_in(extra, [:scenario, :title])}
+          {"Scenario", get_in(extra, [:scenario, :title])},
+          {"Step", get_in(extra, [:cucumber_expression])}
         ]
         |> Enum.reject(fn {title, value} -> is_nil(value) end)
-        |> Enum.map_join(" ", fn {title, value} -> title <> " " <> inspect(value) end)
+        |> Enum.map_join("\n", fn {title, value} -> title <> " " <> inspect(value) end)
       end
     end
   end

--- a/apps/ex_cucumber/mix.exs
+++ b/apps/ex_cucumber/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExCucumber.MixProject do
   use Mix.Project
 
-  @vsn "0.1.5"
+  @vsn "0.1.6"
   @github "https://github.com/Ajwah/ex_cucumber/tree/master/apps/ex_cucumber"
   @name "ExCucumber"
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CucumberElixir.MixProject do
   def project do
     [
       apps_path: "apps",
-      version: "0.1.1",
+      version: "0.1.2",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
Output test duration after each test on success or failure. This replaces the standard "." output.

```
Feature "Book Store"
Scenario "Find books by author"
Step "I search for books by author Erik Larson" passed in 0ms

Feature "Book Store"
Scenario "Find books by author"
Step "I find 2 books" failed after 0ms
```