### PR TITLE
`FunctionClauseError` when a non-cucumber exception is raised

### DIFF
--- a/apps/ex_cucumber/lib/ex_cucumber.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber.ex
@@ -160,13 +160,13 @@ defmodule ExCucumber do
             {result, def_meta}
           rescue
             error ->
-              callback_on_error(ctx, start_time)
-
-              error_code = :error_raised
-              updated_ctx = Ctx.extra(ctx, %{def_meta: def_meta, raised_error: error})
-              exception = ExCucumber.Exceptions.StepError.exception({error_code, updated_ctx})
-              ExCucumber.Exceptions.StepError.message(exception)
-              reraise error, __STACKTRACE__
+              ExCucumber.Exceptions.StepError.raise(
+                Ctx.extra(ctx, %{
+                  def_meta: def_meta,
+                  raised_error: error
+                }),
+                :error_raised
+              )
           catch
             _ ->
               callback_on_error(ctx, start_time)

--- a/apps/ex_cucumber/lib/ex_cucumber.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber.ex
@@ -98,16 +98,16 @@ defmodule ExCucumber do
                 |> case do
                   [] ->
                     raise "No matches found: #{inspect([ids: ctx.extra.fun, meta: @meta],
-                          pretty: true,
-                          limit: :infinity)}"
+                    pretty: true,
+                    limit: :infinity)}"
 
                   [e] ->
                     {e, @meta[e]}
 
                   multiple_matches_ambiguity ->
                     raise "Multiple matches found: #{inspect([multiple_matches_ambiguity: multiple_matches_ambiguity, extra: ctx.extra, meta: @meta],
-                          pretty: true,
-                          limit: :infinity)}"
+                    pretty: true,
+                    limit: :infinity)}"
                 end
             end
           else

--- a/apps/ex_cucumber/lib/ex_cucumber/config.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber/config.ex
@@ -41,7 +41,7 @@ defmodule ExCucumber.Config do
   def project_root, do: @project_root
   def macro_style, do: @macro_style
   def macro_style(:counterpart), do: :counterparts |> macro_styles |> List.first()
-  def error_detail_level, do: @error_detail_level
+  def error_detail_level, do: Application.get_env(:ex_cucumber, :error_detail_level)
 
   def all_best_practices, do: @all_best_practices
   def best_practices, do: @best_practices

--- a/apps/ex_cucumber/lib/ex_cucumber/exceptions/messages/messages.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber/exceptions/messages/messages.ex
@@ -96,4 +96,8 @@ defmodule ExCucumber.Exceptions.Messages do
       true -> raise f
     end
   end
+
+  def render(error, detail_level: _detail_level) do
+    {@step_error_heading, inspect(error)}
+  end
 end

--- a/apps/ex_cucumber/lib/ex_cucumber/exceptions/step_error.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber/exceptions/step_error.ex
@@ -16,7 +16,7 @@ defmodule ExCucumber.Exceptions.StepError do
 
   @impl true
   def message(%__MODULE__{} = e) do
-    Messages.render(e)
+    Messages.render(e, false)
   end
 
   def raise(error_code) do

--- a/apps/ex_cucumber/mix.exs
+++ b/apps/ex_cucumber/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExCucumber.MixProject do
   use Mix.Project
 
-  @vsn "0.1.6"
+  @vsn "0.1.7"
   @github "https://github.com/Ajwah/ex_cucumber/tree/master/apps/ex_cucumber"
   @name "ExCucumber"
 

--- a/apps/ex_cucumber/test/ex_cucumber_test.exs
+++ b/apps/ex_cucumber/test/ex_cucumber_test.exs
@@ -40,6 +40,8 @@ defmodule ExCucumberTest do
       "#{@support_module_dir}/book_store_feature/demonstrate_match_failure_callback.ex",
     BookStoreFeature.DemonstrateRaiseFailureCallback =>
       "#{@support_module_dir}/book_store_feature/demonstrate_raise_failure_callback.ex",
+    BookStoreFeature.DemonstrateRaiseRenderedCallback =>
+      "#{@support_module_dir}/book_store_feature/demonstrate_raise_rendered_callback.ex",
     BookStoreFeature.DemonstrateThrowFailureCallback =>
       "#{@support_module_dir}/book_store_feature/demonstrate_throw_failure_callback.ex",
     BookStoreFeature.DemonstrateExitFailureCallback =>
@@ -199,6 +201,19 @@ defmodule ExCucumberTest do
         end)
 
       assert log =~ "Escaped with state"
+    end
+
+    @tag test_module: BookStoreFeature.DemonstrateRaiseRenderedCallback
+    test "Callback invoked with a raise that isn't explicitly supported", ctx do
+      Application.put_env(:ex_cucumber, :error_detail_level, :brief)
+
+      # Raises because the exit causes a BadMapError in the StepTraverser.
+      assert_raise(BadMapError, fn ->
+        recompile(ctx: ctx)
+      end)
+
+      # Test how the error is going to be rendered.
+      assert ExCucumber.Exceptions.Messages.render(BadMapError, false) == "BadMapError\n"
     end
 
     @tag test_module: RuleFeature.DemonstrateRuleUsage

--- a/apps/ex_cucumber/test/ex_cucumber_test.exs
+++ b/apps/ex_cucumber/test/ex_cucumber_test.exs
@@ -143,38 +143,23 @@ defmodule ExCucumberTest do
     @tag test_module: BookStoreFeature.DemonstrateAssertFailureCallback,
          error_code: :error_raised
     test "Callback invoked with Assert failure", ctx do
-      {_, log} =
-        with_log([level: :info], fn ->
-          assert_raise(ExUnit.AssertionError, fn ->
-            recompile(ctx: ctx)
-          end)
-        end)
-
-      assert log =~ "Escaped with state"
+      assert_specific_raise(StepError, ctx.error_code, fn ->
+        recompile(ctx: ctx)
+      end)
     end
 
     @tag test_module: BookStoreFeature.DemonstrateMatchFailureCallback
     test "Callback invoked with match failure", ctx do
-      {_, log} =
-        with_log([level: :info], fn ->
-          assert_raise(MatchError, fn ->
-            recompile(ctx: ctx)
-          end)
-        end)
-
-      assert log =~ "Escaped with state"
+      assert_raise(StepError, fn ->
+        recompile(ctx: ctx)
+      end)
     end
 
     @tag test_module: BookStoreFeature.DemonstrateRaiseFailureCallback
     test "Callback invoked with raise failure", ctx do
-      {_, log} =
-        with_log([level: :info], fn ->
-          assert_raise(ArithmeticError, "Infinite books!", fn ->
-            recompile(ctx: ctx)
-          end)
-        end)
-
-      assert log =~ "Escaped with state"
+      assert_raise(StepError, fn ->
+        recompile(ctx: ctx)
+      end)
     end
 
     @tag test_module: BookStoreFeature.DemonstrateThrowFailureCallback
@@ -205,17 +190,9 @@ defmodule ExCucumberTest do
 
     @tag test_module: BookStoreFeature.DemonstrateRaiseRenderedCallback
     test "Callback invoked with a raise that isn't explicitly supported", ctx do
-      Application.put_env(:ex_cucumber, :error_detail_level, :brief)
-
-      {_, log} =
-        with_log([level: :info], fn ->
-          # Raises because the exit causes a BadMapError in the StepTraverser.
-          assert_raise(BadMapError, fn ->
-            recompile(ctx: ctx)
-          end)
-        end)
-
-      assert log =~ "Escaped with state"
+      assert_raise(StepError, fn ->
+        recompile(ctx: ctx)
+      end)
     end
 
     @tag test_module: RuleFeature.DemonstrateRuleUsage

--- a/apps/ex_cucumber/test/ex_cucumber_test.exs
+++ b/apps/ex_cucumber/test/ex_cucumber_test.exs
@@ -145,7 +145,7 @@ defmodule ExCucumberTest do
     test "Callback invoked with Assert failure", ctx do
       {_, log} =
         with_log([level: :info], fn ->
-          assert_specific_raise(StepError, ctx.error_code, fn ->
+          assert_raise(ExUnit.AssertionError, fn ->
             recompile(ctx: ctx)
           end)
         end)
@@ -207,13 +207,15 @@ defmodule ExCucumberTest do
     test "Callback invoked with a raise that isn't explicitly supported", ctx do
       Application.put_env(:ex_cucumber, :error_detail_level, :brief)
 
-      # Raises because the exit causes a BadMapError in the StepTraverser.
-      assert_raise(BadMapError, fn ->
-        recompile(ctx: ctx)
-      end)
+      {_, log} =
+        with_log([level: :info], fn ->
+          # Raises because the exit causes a BadMapError in the StepTraverser.
+          assert_raise(BadMapError, fn ->
+            recompile(ctx: ctx)
+          end)
+        end)
 
-      # Test how the error is going to be rendered.
-      assert ExCucumber.Exceptions.Messages.render(BadMapError, false) == "BadMapError\n"
+      assert log =~ "Escaped with state"
     end
 
     @tag test_module: RuleFeature.DemonstrateRuleUsage

--- a/apps/ex_cucumber/test/support/modules/book_store_feature/demonstrate_raise_rendered_callback.ex
+++ b/apps/ex_cucumber/test/support/modules/book_store_feature/demonstrate_raise_rendered_callback.ex
@@ -1,8 +1,13 @@
 defmodule Support.BookStoreFeature.DemonstrateRaiseRenderedCallback do
   use ExCucumber
   @feature "book_store.feature"
+  @on_error &__MODULE__.escape/1
 
   require Logger
+
+  def escape(context) do
+    Logger.error("Escaped with state #{inspect(context.extra.state)}")
+  end
 
   defmodule BookStore do
     def find_by_author(books, author) do

--- a/apps/ex_cucumber/test/support/modules/book_store_feature/demonstrate_raise_rendered_callback.ex
+++ b/apps/ex_cucumber/test/support/modules/book_store_feature/demonstrate_raise_rendered_callback.ex
@@ -1,0 +1,57 @@
+defmodule Support.BookStoreFeature.DemonstrateRaiseRenderedCallback do
+  use ExCucumber
+  @feature "book_store.feature"
+
+  require Logger
+
+  defmodule BookStore do
+    def find_by_author(books, author) do
+      books
+      |> Enum.filter(fn e ->
+        match?(%{"author" => ^author}, e)
+      end)
+    end
+
+    def find_by_title(books, title) do
+      books
+      |> Enum.filter(fn e ->
+        match?(%{"title" => ^title}, e)
+      end)
+    end
+  end
+
+  Given._ "I have the following books in the store", args do
+    {:ok, %{books: args.data_table}}
+  end
+
+  # Scenario: Find books by author
+  # Scenario: Find books by author, but isn't there
+  When._ "I search for books by author {author}", args do
+    author = Keyword.fetch!(args.params, :author)
+    results = BookStore.find_by_author(args.state.books, author)
+    {:ok, %{results: results}}
+  end
+
+  Then._ "I find {int} books", args do
+    expected_amount = Keyword.fetch!(args.params, :int)
+    assert expected_amount == Enum.count(args.state.results)
+  end
+
+  # Scenario: Find book by title
+  # Scenario: Find book by title, but isn't there
+  When._ "I search for a book titled {title}", args do
+    title = Keyword.fetch!(args.params, :title)
+    results = BookStore.find_by_title(args.state.books, title)
+    {:ok, %{results: results}}
+  end
+
+  Then._ "I find a book", args do
+    # Raise a BadMapError.
+    Map.get(args, :missing_arg)
+    |> Map.fetch!(:missing_key)
+  end
+
+  Then._ "I find no book", args do
+    assert Enum.count(args.state.results) == 0
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CucumberElixir.MixProject do
   def project do
     [
       apps_path: "apps",
-      version: "0.1.2",
+      version: "0.1.3",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
Handle errors not supported by `ex_cucumber` by reporting a step error and then the whole error struct.
Addressing [#102](https://github.com/arboricity/customer_confidence/issues/102).

E.g.:
![image](https://github.com/arboricity/ex_cucumber/assets/5666984/bed38b4d-3873-41c2-a42f-c3f1aaea8eb3)